### PR TITLE
Update build instructions (Fix #22, thanks @JustinDrake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ To run all tests and generate test and coverage reports: `make test`
 
 The specs are tested using test-vectors shared between Eth 2.0 clients,
  found here: [`ethereum/eth2.0-spec-tests`](https://github.com/ethereum/eth2.0-spec-tests).
-Instructions on the usage of these test-vectors with ZRNT can be found in the [testing readme](./tests/spec/README.md).
+Instructions on the usage of these test-vectors with ZRNT can be found in the [testing readme](./tests/spec/README.md)
+ (TLDR: run `make download-tests` first).
 
 #### Coverage reports
 

--- a/README.md
+++ b/README.md
@@ -60,20 +60,26 @@ SSZ is provided by two components:
 
 ### Building
 
-Re-generate dynamic parts by running `go generate ./...` (make sure the needed configuration files are in `./presets/configs/`).
+ZRNT is a library, to use it in action, try [ZCLI](github.com/protolambda/zcli) or [Rumor](github.com/protolambda/rumor).
+
+#### Customizing configuration
+
+The common configurations are already included by default, no need to add or run anything if you just need `mainnet` or `minimal` spec.
+
+For custom configurations, add one or more configuration files to `./presets/configs/`.
+Then, re-generate the dynamic parts by running `go generate ./...`.
+
+#### Choosing a config
 
 By default, the `defaults.go` preset is used, which is selected if no other presets are,
 i.e. `!preset_mainnet,!preset_minimal` if `mainnet` and `minimal` are the others.
 
-For custom configuration, add a build-constraint (also known as "build tag") when building ZRNT or using it as a dependency:
+To make a specific configuration effective, add a build-constraint (also known as "build tag") when building ZRNT or using it as a dependency:
 
-```
-go build -tags preset_mainnet
-
-or
-
-go build -tags preset_minimal
-
+```shell script
+# Examples, Go commands are all consistent, something like:
+go test -tags preset_minimal ./...
+go build -tags preset_minimal ./...
 ```
 
 BLS can be turned off by adding the `bls_off` build tag (security warning: for testing use only!).


### PR DESCRIPTION
Update the build instructions, to reflect that:
- Defaults are already there, no need to run anything
- When building, select the whole package tree, a.k.a. `./...`
- ZRNT is a library, nothing to build directly unless you're statically linking things. Try ZCLI or Rumor
- Which part is important to pick a config, e.g. during testing

Thank @JustinDrake for reminding me to update the docs in #22
