### PR TITLE
Fix JSON Marshalling for several objects

### DIFF
--- a/eth2/beacon/common/logs_bloom.go
+++ b/eth2/beacon/common/logs_bloom.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 
 	"github.com/protolambda/ztyp/codec"
@@ -93,4 +94,8 @@ func (p *LogsBloom) UnmarshalText(text []byte) error {
 		return errors.New("cannot decode into nil logs bloom")
 	}
 	return conv.FixedBytesUnmarshalText(p[:], text[:])
+}
+
+func (p LogsBloom) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
 }

--- a/eth2/beacon/common/transactions.go
+++ b/eth2/beacon/common/transactions.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 
 	"github.com/protolambda/ztyp/codec"
@@ -29,6 +30,18 @@ func (txs PayloadTransactions) Serialize(spec *Spec, w *codec.EncodingWriter) er
 	return w.List(func(i uint64) codec.Serializable {
 		return spec.Wrap(&txs[i])
 	}, 0, uint64(len(txs)))
+}
+
+func (txs PayloadTransactions) MarshalJSON() ([]byte, error) {
+	var transactions []Transaction
+	if len(txs) == 0 {
+		return json.Marshal([]Transaction{})
+	} else {
+		for _, v := range txs {
+			transactions = append(transactions, v)
+		}
+	}
+	return json.Marshal(transactions)
 }
 
 func (txs PayloadTransactions) ByteLength(spec *Spec) (out uint64) {

--- a/eth2/beacon/common/withdrawals.go
+++ b/eth2/beacon/common/withdrawals.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -184,6 +185,18 @@ func (ws Withdrawals) Serialize(spec *Spec, w *codec.EncodingWriter) error {
 	return w.List(func(i uint64) codec.Serializable {
 		return &ws[i]
 	}, WithdrawalType.TypeByteLength(), uint64(len(ws)))
+}
+
+func (ws Withdrawals) MarshalJSON() ([]byte, error) {
+	var withdrawals []Withdrawal
+	if len(ws) == 0 {
+		return json.Marshal([]Withdrawal{})
+	} else {
+		for _, v := range ws {
+			withdrawals = append(withdrawals, v)
+		}
+	}
+	return json.Marshal(withdrawals)
 }
 
 func (ws Withdrawals) ByteLength(spec *Spec) (out uint64) {
@@ -383,6 +396,18 @@ func (li SignedBLSToExecutionChanges) Serialize(_ *Spec, w *codec.EncodingWriter
 	return w.List(func(i uint64) codec.Serializable {
 		return &li[i]
 	}, SignedBLSToExecutionChangeType.TypeByteLength(), uint64(len(li)))
+}
+
+func (li SignedBLSToExecutionChanges) MarshalJSON() ([]byte, error) {
+	changes := []SignedBLSToExecutionChange{}
+	if len(li) == 0 {
+		return json.Marshal([]SignedBLSToExecutionChange{})
+	} else {
+		for _, v := range li {
+			changes = append(changes, v)
+		}
+	}
+	return json.Marshal(changes)
 }
 
 func (li SignedBLSToExecutionChanges) ByteLength(_ *Spec) (out uint64) {

--- a/eth2/beacon/phase0/attester_slashing.go
+++ b/eth2/beacon/phase0/attester_slashing.go
@@ -2,6 +2,7 @@ package phase0
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -73,6 +74,18 @@ func (a AttesterSlashings) Serialize(spec *common.Spec, w *codec.EncodingWriter)
 	return w.List(func(i uint64) codec.Serializable {
 		return spec.Wrap(&a[i])
 	}, 0, uint64(len(a)))
+}
+
+func (a AttesterSlashings) MarshalJSON() ([]byte, error) {
+	var slashings []AttesterSlashing
+	if len(a) == 0 {
+		return json.Marshal([]AttesterSlashing{})
+	} else {
+		for _, v := range a {
+			slashings = append(slashings, v)
+		}
+	}
+	return json.Marshal(slashings)
 }
 
 func (a AttesterSlashings) ByteLength(spec *common.Spec) (out uint64) {

--- a/eth2/beacon/phase0/deposit.go
+++ b/eth2/beacon/phase0/deposit.go
@@ -2,6 +2,7 @@ package phase0
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -34,6 +35,17 @@ func (a Deposits) Serialize(spec *common.Spec, w *codec.EncodingWriter) error {
 	}, common.DepositType.TypeByteLength(), uint64(len(a)))
 }
 
+func (a Deposits) MarshalJSON() ([]byte, error) {
+	var deposits []common.Deposit
+	if len(a) == 0 {
+		return json.Marshal([]common.Deposit{})
+	} else {
+		for _, v := range a {
+			deposits = append(deposits, v)
+		}
+	}
+	return json.Marshal(deposits)
+}
 func (a Deposits) ByteLength(*common.Spec) (out uint64) {
 	return common.DepositType.TypeByteLength() * uint64(len(a))
 }

--- a/eth2/beacon/phase0/proposer_slashing.go
+++ b/eth2/beacon/phase0/proposer_slashing.go
@@ -2,6 +2,7 @@ package phase0
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -62,6 +63,18 @@ func (a ProposerSlashings) Serialize(_ *common.Spec, w *codec.EncodingWriter) er
 	return w.List(func(i uint64) codec.Serializable {
 		return &a[i]
 	}, ProposerSlashingType.TypeByteLength(), uint64(len(a)))
+}
+
+func (a ProposerSlashings) MarshalJSON() ([]byte, error) {
+	var slashings []ProposerSlashing
+	if len(a) == 0 {
+		return json.Marshal([]ProposerSlashing{})
+	} else {
+		for _, v := range a {
+			slashings = append(slashings, v)
+		}
+	}
+	return json.Marshal(slashings)
 }
 
 func (a ProposerSlashings) ByteLength(_ *common.Spec) (out uint64) {

--- a/eth2/beacon/phase0/voluntary_exit.go
+++ b/eth2/beacon/phase0/voluntary_exit.go
@@ -2,6 +2,7 @@ package phase0
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -30,6 +31,18 @@ func (a VoluntaryExits) Serialize(spec *common.Spec, w *codec.EncodingWriter) er
 	return w.List(func(i uint64) codec.Serializable {
 		return &a[i]
 	}, SignedVoluntaryExitType.TypeByteLength(), uint64(len(a)))
+}
+
+func (a VoluntaryExits) MarshalJSON() ([]byte, error) {
+	var exits []SignedVoluntaryExit
+	if len(a) == 0 {
+		return json.Marshal([]VoluntaryExit{})
+	} else {
+		for _, v := range a {
+			exits = append(exits, v)
+		}
+	}
+	return json.Marshal(exits)
 }
 
 func (a VoluntaryExits) ByteLength(spec *common.Spec) (out uint64) {


### PR DESCRIPTION
PR tweaks two behaviors related to marshaling zrnt objects to json. 

1.  Logsbloom over json is encoded as a list instead of an array of bytes
2. Many list backed objects that are empty when marshaling json end up using null instead of an empty list

If its desirable I could also add round trip tests for json encoding of spec objects. 